### PR TITLE
JasPer static build

### DIFF
--- a/easyconfigs/JasPer-2.0.12-CrayGNU-2017.06-static.eb
+++ b/easyconfigs/JasPer-2.0.12-CrayGNU-2017.06-static.eb
@@ -1,0 +1,36 @@
+easyblock = 'CMakeMake'
+
+name = 'JasPer'
+version = '2.0.12'
+versionsuffix = 'static'
+
+homepage = 'http://www.ece.uvic.ca/~frodo/jasper/'
+description = """The JasPer Project is an open-source initiative to provide a free
+ software-based reference implementation of the codec specified in the JPEG-2000 Part-1 standard.
+ This is a statically linked version of JasPer."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2017.06'}
+toolchainopts = {'static' : True}
+
+source_urls = ['http://www.ece.uvic.ca/~frodo/jasper/software/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['5b24faf5ed38670d6286e45ab7516b26458d05e7929b435afe569176765f4dda']
+
+builddependencies = [('jpeg', '9c', 'static')]
+
+osdependencies = [('cmake')]
+
+# Required by CMake
+separate_build_dir = True
+
+# Missing dependency
+configopts = '-DJAS_ENABLE_OPENGL=OFF -DJAS_ENABLE_DOC=OFF -DJAS_ENABLE_SHARED=FALSE'
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ["bin/imgcmp", "bin/imginfo", "bin/jasper", "lib64/libjasper.a" ],
+    'dirs': ["include"],
+}
+
+moduleclass = 'vis'

--- a/easyconfigs/jpeg-9-CrayGNU-static.eb
+++ b/easyconfigs/jpeg-9-CrayGNU-static.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'jpeg'
+version = '9c'
+versionsuffix = 'static'
+
+homepage = 'http://www.ijg.org/'
+description = """The JasPer Project is an open-source initiative to provide a free
+ software-based reference implementation of the codec specified in the JPEG-2000 Part-1 standard."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2017.06'}
+toolchainopts = {'static' : True, 'pic' : True}
+
+source_urls = ['http://www.ijg.org/files']
+sources = ['jpegsrc.v9c.tar.gz']
+checksums = ['1f3a3f610f57e88ff3f1f9db530c605f3949ee6e78002552e324d493cf086ad4']
+
+# Missing dependency
+#configopts = ''
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': ['lib/libjpeg.a'],
+    'dirs': ['bin'],
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
Additional JasPer configuration files for a statically linked build.
JasPer is dependent on JPEG, thus we also need that to build it statically.