### PR TITLE
Vtk kupe

### DIFF
--- a/easyconfigs/VTK-lite-8.1.1-CrayGNU-2017.06.eb
+++ b/easyconfigs/VTK-lite-8.1.1-CrayGNU-2017.06.eb
@@ -25,9 +25,9 @@ dependencies = [
 ]
 
 preconfigopts = 'export CRAYPE_LINK_TYPE=dynamic && '
-configopts  = "-DCMAKE_BUILD_TYPE=Release -DVTK_Group_Rendering=OFF -DVTK_Group_Standalone=OFF "
-configopts += "-DModule_vtkCommonColor=ON -DModule_vtkCommonComputationalGeometry=ON "
-configopts += "-DModule_vtkCommonCore=ON "
+configopts  = "-DCMAKE_BUILD_TYPE=Release -DVTK_Group_Rendering=OFF -DVTK_Group_Standalone=ON "
+#configopts += "-DModule_vtkCommonColor=ON -DModule_vtkCommonComputationalGeometry=ON "
+#configopts += "-DModule_vtkCommonCore=ON "
 
 sanity_check_paths = {
     'files': ['bin/vtk%s-%%(version_major_minor)s' % x for x in ['EncodeString', 'HashSource']],

--- a/easyconfigs/VTK-lite-8.1.1-CrayGNU-2017.06.eb
+++ b/easyconfigs/VTK-lite-8.1.1-CrayGNU-2017.06.eb
@@ -1,0 +1,40 @@
+easyblock = 'CMakeMake'
+
+name = 'VTK-lite'
+version = '8.1.1'
+
+homepage = 'http://www.vtk.org'
+description = """The Visualization Toolkit (VTK) is an open-source, freely available software system for
+ 3D computer graphics, image processing and visualization. VTK consists of a C++ class library and several
+ interpreted interface layers including Tcl/Tk, Java, and Python. VTK supports a wide variety of visualization
+ algorithms including: scalar, vector, tensor, texture, and volumetric methods; and advanced modeling techniques
+ such as: implicit modeling, polygon reduction, mesh smoothing, cutting, contouring, and Delaunay triangulation."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2017.06'}
+
+source_urls = ['http://www.vtk.org/files/release/%(version_major_minor)s']
+sources = [
+    'VTK-%(version)s.tar.gz',
+    'VTKData-%(version)s.tar.gz',
+]
+
+builddependencies = [('CMake', '3.12.0')]
+
+dependencies = [
+   ('PROJ', '4.9.3'),
+]
+
+preconfigopts = 'export CRAYPE_LINK_TYPE=dynamic && '
+configopts  = "-DCMAKE_BUILD_TYPE=Release -DVTK_Group_Rendering=OFF -DVTK_Group_Standalone=OFF "
+configopts += "-DModule_vtkCommonColor=ON -DModule_vtkCommonComputationalGeometry=ON "
+configopts += "-DModule_vtkCommonCore=ON "
+
+sanity_check_paths = {
+    'files': ['bin/vtk%s-%%(version_major_minor)s' % x for x in ['EncodeString', 'HashSource']],
+    'dirs': ['include/vtk-%(version_major_minor)s'],
+}
+
+#sanity_check_commands = [('python', "-c 'import vtk'")]
+
+moduleclass = 'vis'
+

--- a/easyconfigs/VTK-lite-8.1.1-CrayIntel-2017.06.eb
+++ b/easyconfigs/VTK-lite-8.1.1-CrayIntel-2017.06.eb
@@ -14,7 +14,7 @@ This version of VTK has rendering turned off -- users can link against this libr
 but they will not be able to render.
 """
 
-toolchain = {'name': 'CrayGNU', 'version': '2017.06'}
+toolchain = {'name': 'CrayIntel', 'version': '2017.06'}
 
 source_urls = ['http://www.vtk.org/files/release/%(version_major_minor)s']
 sources = [

--- a/easyconfigs/VTK-lite-8.1.1-CrayIntel-2017.06.eb
+++ b/easyconfigs/VTK-lite-8.1.1-CrayIntel-2017.06.eb
@@ -26,8 +26,14 @@ builddependencies = [('CMake', '3.12.0')]
 
 dependencies = []
 
-preconfigopts = 'export CRAYPE_LINK_TYPE=dynamic && '
-configopts  = "-DCMAKE_BUILD_TYPE=Release -DVTK_Group_Rendering=OFF -DVTK_Group_Standalone=ON "
+configopts  = "-DCMAKE_BUILD_TYPE=Release -DVTK_Group_Rendering=OFF -DVTK_Group_Standalone=OFF "
+configopts += "-DModule_vtkChartsCore:BOOL=ON -DModule_vtkCommonColor:BOOL=ON "
+configopts += "-DModule_vtkCommonCore:BOOL=ON -DModule_vtkCommonDataModel:BOOL=ON -DModule_vtkCommonTransforms:BOOL=ON "
+configopts += "-DModule_vtkFiltersCore:BOOL=ON -DModule_vtkCommonMath:BOOL=ON -DModule_vtkCommonExecutionModel:BOOL=ON "
+configopts += "-DModule_vtkIOCore:BOOL=ON -DModule_vtkIOLegacy:BOOL=ON "
+configopts += "-DModule_vtkImagingCore:BOOL=ON "
+configopts += "-DModule_vtkCommonSystem:BOOL=ON -DModule_vtksys:BOOL=ON "
+configopts += "-DModule_vtkCommonMisc:BOOL=ON "
 
 sanity_check_paths = {
     'files': ['bin/vtk%s-%%(version_major_minor)s' % x for x in ['EncodeString', 'HashSource']],


### PR DESCRIPTION
Hi @tinyendian. 
Please accept this PR and install VTK-lite on kupe. This version of VTK has rendering turned off and so is suitable for code that uses VTK algorithm without doing any visualization (e.g. mint). 